### PR TITLE
LeftDrawer Design Update

### DIFF
--- a/client/atom/src/components/Home/styles.js
+++ b/client/atom/src/components/Home/styles.js
@@ -66,7 +66,6 @@ export const useStyles = makeStyles(theme => ({
     alignItems: 'flex-end',
     display: 'flex',
     marginLeft: '-15px',
-    marginTop: '20px',
   },
   menuHeaderListItemText: {
     fontSize: '0.9em',
@@ -85,13 +84,29 @@ export const useStyles = makeStyles(theme => ({
     display: 'inline-flex',
     padding: '2px 22px 2px 12px',
     width: 'auto',
-    color: "#418CDD"
+    color: "#418CDD",
+    marginBottom: "1rem"
+  },
+  menuListItemThumbnailContainer:{
+    border: ".5px solid #418CDD", 
+    borderRadius: "5px", 
+    overflow: "hidden", 
+    marginBottom: "1rem"
+  },
+  menuListItemThumbnailHeader: {
+    display: "flex", 
+    alignItems: "center", 
+    margin: ".25rem .5rem", 
+    cursor: "pointer"
   },
   menuListItemIcon: {
     minWidth: '36px',
     color: "#418CDD"
   },
-  vectorThumbnail: {maxHeight: "72px",overflow: "hidden", margin: "12px 0", borderRadius: ".5rem", border: "0.5px solid #418CDD"},
+  vectorThumbnail: {
+    maxHeight: "72px",
+    overflow: "hidden"
+  },
   //top drawer
   topDrawer: {
     // width: '100%',

--- a/client/atom/src/config/Demo/QueryBuilderContent.js
+++ b/client/atom/src/config/Demo/QueryBuilderContent.js
@@ -10,6 +10,10 @@ export const QueryBuilderContent = {
   "description": "Enable business users to self serve on data and answer their own questions",
   "icon": SearchIcon,
   "component": QueryBuilder,
+  "thumbnail": {
+    id: "1",
+    offset: "0 -72px",
+  },
   "lookerContent": [
     {
       "type": "explorelite",

--- a/client/atom/src/config/Demo/SalesOverviewContent.js
+++ b/client/atom/src/config/Demo/SalesOverviewContent.js
@@ -191,6 +191,10 @@ export const SalesOverviewContent = {
   "description": "Overview of all your sales!",
   "icon": VisibilityOutlinedIcon,
   "component": Dashboard,
+  "thumbnail": {
+    id: "9",
+    offset: "0 -200px",
+  },
   "lookerContent": [
     {
       "type": "dashboard",

--- a/client/atom/src/config/Demo/WebAnalyticsContent.js
+++ b/client/atom/src/config/Demo/WebAnalyticsContent.js
@@ -76,7 +76,6 @@ export const WebAnalyticsContent = {
   "component": Dashboard,
   "thumbnail": {
     id: "9",
-    url: "webanalytics"
   },
   "lookerContent": [
     {

--- a/client/shared/components/LeftDrawer.js
+++ b/client/shared/components/LeftDrawer.js
@@ -86,7 +86,20 @@ function MenuList({ classes, DemoComponentsContentArr }) {
               const to = validIdHelper(_.lowerCase(item.label))
               const selected = to === selectedMenuItem
 
-              return (
+
+              return item.thumbnail ?
+                <Link to={to} style={{textDecoration: "none"}}>
+                  <div className={classes.menuListItemThumbnailContainer}>
+                    <div className={classes.menuListItemThumbnailHeader}>
+                      <ListItemIcon className={classes.menuListItemIcon} >
+                        {MatchingIconComponent ? <MatchingIconComponent /> : <></>}
+                      </ListItemIcon>
+                      <ListItemText primary={_.capitalize(item.label)} style={{color: "#418CDD"}}/>
+                    </div>
+                    {item.thumbnail && <VectorThumbnail classes={classes} {...item.thumbnail}/>}
+                  </div>
+                </Link>
+              :(
                 <>
                 <ListItem
                   button
@@ -101,7 +114,6 @@ function MenuList({ classes, DemoComponentsContentArr }) {
                   </ListItemIcon>
                   <ListItemText primary={_.capitalize(item.label)} />
                 </ListItem>
-                {item.thumbnail && <VectorThumbnail classes={classes} {...item.thumbnail}/>}
                 </>
                 )
             })}

--- a/client/shared/components/VectorThumbnail.js
+++ b/client/shared/components/VectorThumbnail.js
@@ -4,7 +4,7 @@ import { Grid } from '@material-ui/core';
 import { ApiHighlight } from './Accessories/Highlight';
 import { appContextMap } from '../utils/tools';
 
-export function VectorThumbnail({ classes, id, url }) {
+export function VectorThumbnail({ classes, id, offset}) {
   const [svg, setSvg] = useState(null)
   const { clientSession, sdk, corsApiCall, isReady } = useContext(appContextMap[process.env.REACT_APP_PACKAGE_NAME])
   const {lookerUser } = clientSession;
@@ -30,6 +30,11 @@ export function VectorThumbnail({ classes, id, url }) {
     return url;
   }
 
+  const imgStyle = offset ? {
+    objectPosition: offset, 
+    objectFit: 'cover'
+  } : {};
+
   return svg ? (
     <ApiHighlight classes={classes}>
       <div className={classes.vectorThumbnail}>
@@ -37,7 +42,7 @@ export function VectorThumbnail({ classes, id, url }) {
           className={`${classes.cursorPointer}`}
           spacing={3}>
           <div className={` ${classes.maxHeight60} ${classes.cursorPointer} ${classes.overflowHidden}`}>
-            <img src={svg}/>
+            <img src={svg} style={imgStyle}/>
           </div>
         </Grid >
       </div>

--- a/client/shared/components/VectorThumbnail.js
+++ b/client/shared/components/VectorThumbnail.js
@@ -35,8 +35,7 @@ export function VectorThumbnail({ classes, id, url }) {
       <Grid container
         className={`${classes.cursorPointer}`}
         spacing={3}
-        component={Link}
-        to={url}
+        
       >
         <ApiHighlight classes={classes}>
           <div className={` ${classes.maxHeight60} ${classes.cursorPointer} ${classes.overflowHidden}`}>

--- a/client/shared/components/VectorThumbnail.js
+++ b/client/shared/components/VectorThumbnail.js
@@ -31,18 +31,16 @@ export function VectorThumbnail({ classes, id, url }) {
   }
 
   return svg ? (
-    <div className={classes.vectorThumbnail}>
-      <Grid container
-        className={`${classes.cursorPointer}`}
-        spacing={3}
-        
-      >
-        <ApiHighlight classes={classes}>
+    <ApiHighlight classes={classes}>
+      <div className={classes.vectorThumbnail}>
+        <Grid container
+          className={`${classes.cursorPointer}`}
+          spacing={3}>
           <div className={` ${classes.maxHeight60} ${classes.cursorPointer} ${classes.overflowHidden}`}>
             <img src={svg}/>
           </div>
-        </ApiHighlight>
-      </Grid >
-    </div>
+        </Grid >
+      </div>
+    </ApiHighlight>
   ) : null;
 }


### PR DESCRIPTION
This updates the VectorThumbnails on certain items to appear "inside" the menu list option. Below shows how the left draw looks before/the design/in this PR, more than happy to include other smaller styling updates if necessary.

The design also have a thumbnail for every menu item, which we don't have currently. So I decided to keep the old pill designs for the items without thumbnails (eg "Query builder", "Saved reports" etc.) for now.

|Before | New Design | This PR
|-|-|-
![image](https://user-images.githubusercontent.com/85196294/135338825-6d699c5a-8961-498f-babe-8a2fc182fbb5.png) | ![image](https://user-images.githubusercontent.com/85196294/135338358-40641fd6-cdf3-4a94-b6da-679719705515.png) | ![image](https://user-images.githubusercontent.com/85196294/135338276-665e84c5-7a89-467b-9896-7cff61a4120c.png)


I also just noticed the ![image](https://user-images.githubusercontent.com/85196294/135339040-b471adaf-f5d7-46ea-8e83-63889f844dca.png) icon in the designs. If this is still wanted, I can include that in a future PR. 
