### PR TITLE
Chappy/release cleanup

### DIFF
--- a/client/atom/src/config/Demo/QueryBuilderContent.js
+++ b/client/atom/src/config/Demo/QueryBuilderContent.js
@@ -10,10 +10,6 @@ export const QueryBuilderContent = {
   "description": "Enable business users to self serve on data and answer their own questions",
   "icon": SearchIcon,
   "component": QueryBuilder,
-  "thumbnail": {
-    id: "1",
-    offset: "0 -72px",
-  },
   "lookerContent": [
     {
       "type": "explorelite",

--- a/client/atom/src/config/Demo/SalesOverviewContent.js
+++ b/client/atom/src/config/Demo/SalesOverviewContent.js
@@ -191,10 +191,6 @@ export const SalesOverviewContent = {
   "description": "Overview of all your sales!",
   "icon": VisibilityOutlinedIcon,
   "component": Dashboard,
-  "thumbnail": {
-    id: "9",
-    offset: "0 -200px",
-  },
   "lookerContent": [
     {
       "type": "dashboard",

--- a/client/atom/src/config/Demo/WebAnalyticsContent.js
+++ b/client/atom/src/config/Demo/WebAnalyticsContent.js
@@ -76,6 +76,7 @@ export const WebAnalyticsContent = {
   "component": Dashboard,
   "thumbnail": {
     id: "9",
+    url: "webanalytics"
   },
   "lookerContent": [
     {

--- a/client/shared/components/EmbeddedQuery.js
+++ b/client/shared/components/EmbeddedQuery.js
@@ -175,7 +175,7 @@ function CategoryFilter({ lookerContentItem, onSelect, classes }) {
 
   return (
     <>
-      <div style={{ display: "flex", alignItems: "center", paddingBottom:"2rem" }}>
+      <div style={{ display: "flex", alignItems: "center", paddingBottom:"2rem", width:"100%" }}>
         <Typography variant="h6" style={{textTransform:"uppercase", fontWeight:600}}>
           Regional Weekly Performance by Category
         </Typography>

--- a/client/shared/components/EmbeddedQuery.js
+++ b/client/shared/components/EmbeddedQuery.js
@@ -202,7 +202,6 @@ function CategoryFilter({ lookerContentItem, onSelect, classes }) {
             style={{
               display: "flex",
               overflow: "auto",
-              // I'm fighting with the combination material ui grids + overflow custom categoryItemFilters. This needs an absolute width, because otherwise the items will overflow and cause the page to appear wider than it is. I'm sure there's some flexbox magic that I can do somehwere in this component or higher up, but this looks good enough on a standard 13inch screen with 100% zoom, can take this on later. 
             }}
           >
             {sorted.map((d) => (

--- a/client/shared/components/EmbeddedQuery.js
+++ b/client/shared/components/EmbeddedQuery.js
@@ -198,11 +198,11 @@ function CategoryFilter({ lookerContentItem, onSelect, classes }) {
       {!loading && !error && sorted && (
         <ApiHighlight classes={classes}>
           <div
+            className={classes.categoryfiltercontainer}
             style={{
               display: "flex",
               overflow: "auto",
               // I'm fighting with the combination material ui grids + overflow custom categoryItemFilters. This needs an absolute width, because otherwise the items will overflow and cause the page to appear wider than it is. I'm sure there's some flexbox magic that I can do somehwere in this component or higher up, but this looks good enough on a standard 13inch screen with 100% zoom, can take this on later. 
-              maxWidth: "1000px",
             }}
           >
             {sorted.map((d) => (

--- a/client/shared/components/VectorThumbnail.js
+++ b/client/shared/components/VectorThumbnail.js
@@ -4,7 +4,7 @@ import { Grid } from '@material-ui/core';
 import { ApiHighlight } from './Accessories/Highlight';
 import { appContextMap } from '../utils/tools';
 
-export function VectorThumbnail({ classes, id, offset}) {
+export function VectorThumbnail({ classes, id, url }) {
   const [svg, setSvg] = useState(null)
   const { clientSession, sdk, corsApiCall, isReady } = useContext(appContextMap[process.env.REACT_APP_PACKAGE_NAME])
   const {lookerUser } = clientSession;
@@ -30,11 +30,6 @@ export function VectorThumbnail({ classes, id, offset}) {
     return url;
   }
 
-  const imgStyle = offset ? {
-    objectPosition: offset, 
-    objectFit: 'cover'
-  } : {};
-
   return svg ? (
     <ApiHighlight classes={classes}>
       <div className={classes.vectorThumbnail}>
@@ -42,7 +37,7 @@ export function VectorThumbnail({ classes, id, offset}) {
           className={`${classes.cursorPointer}`}
           spacing={3}>
           <div className={` ${classes.maxHeight60} ${classes.cursorPointer} ${classes.overflowHidden}`}>
-            <img src={svg} style={imgStyle}/>
+            <img src={svg}/>
           </div>
         </Grid >
       </div>

--- a/client/shared/components/styles.js
+++ b/client/shared/components/styles.js
@@ -341,6 +341,45 @@ export const useStyles = makeStyles((theme) => ({
     border: "none",
     height: "fit-content",
   },
+  categoryfiltercontainer: {
+    maxWidth: "380px",
+    '@media (min-width: 900px)': {
+      maxWidth: "500px"
+    },
+    '@media (min-width: 1000px)': {
+      maxWidth: "620px"
+    },
+    '@media (min-width: 1100px)': {
+      maxWidth: "740px"
+    },
+    '@media (min-width: 1250px)': {
+      maxWidth: "860px"
+    },
+    '@media (min-width: 1350px)': {
+      maxWidth: "980px"
+    },
+    '@media (min-width: 1450px)': {
+      maxWidth: "1130px"
+    },
+    '@media (min-width: 1600px)': {
+      maxWidth: "1250px"
+    },
+    '@media (min-width: 1720px)': {
+      maxWidth: "1380px"
+    },
+    '@media (min-width: 1840px)': {
+      maxWidth: "1500px"
+    },
+    '@media (min-width: 1960px)': {
+      maxWidth: "1620px"
+    },
+    '@media (min-width: 2080px)': {
+      maxWidth: "1740px"
+    },
+    '@media (min-width: 2200px)': {
+      maxWidth: "1860px"
+    },
+  },
   categoryfilteritem: {
     backgroundSize: "cover",
     borderRadius: "50%",


### PR DESCRIPTION
Reverted side nav panels to simple buttons when an image isn't directly available (sorry @alexg-4mile 😺 )

![Screen Shot 2021-09-30 at 6 14 32 PM](https://user-images.githubusercontent.com/773083/135551062-fd44a47e-79a9-4ebc-adf0-f31957112fbf.png)

Bumped nav images under the header text in wide layouts:

![Screen Shot 2021-09-30 at 6 14 38 PM](https://user-images.githubusercontent.com/773083/135551092-f542c00c-851b-437f-b4f7-9a05e7d73404.png)


