### PR TITLE
Splashpage Feedback: Separate Source&Code, show "Open Sandbox"

### DIFF
--- a/client/shared/components/Accessories/CodeFlyout.js
+++ b/client/shared/components/Accessories/CodeFlyout.js
@@ -28,9 +28,10 @@ export const CodeFlyout = (props) => {
           src: link,
           style: {
             position: "absolute",
-            height: "100%",
+            height: "75vh",
             width: "100%",
             border: "none",
+            paddingRight: "2rem"
           }
         }
       })

--- a/client/shared/components/LeftDrawer.js
+++ b/client/shared/components/LeftDrawer.js
@@ -30,8 +30,16 @@ export const LeftDrawer = ({ DemoComponentsContentArr, classes }) => {
 
       <MenuList
         classes={classes}
+        style={{paddingBottom: "2rem"}}
         DemoComponentsContentArr={DemoComponentsContentArr} />
-
+      <div style={{
+          borderTop: "1px solid #dedede", 
+          height: "2rem",
+          paddingBottom: "1rem",
+          width: "100%"
+          }}>
+          <SourceCode classes={classes}/>
+        </div>
     </Drawer>
   )
 }
@@ -122,7 +130,6 @@ function MenuList({ classes, DemoComponentsContentArr }) {
       )
     }) : ''
     }
-    <SourceCode classes={classes}/>
   </List >
   )
 }
@@ -147,9 +154,10 @@ function SourceCode({classes}) {
         className={`${classes.borderRadius100} ${classes.noBorder} ${classes.menuListItemThumbnailContainer}`}
         onClick={toggle}
       >
-        <div className={classes.menuListItemThumbnailHeader} style={{color: "#418CDD",}}>
-        <HighlightOutlined />
-        <ListItemText primary={"Source & Code"} />
+        <div className={classes.menuListItemThumbnailHeader} style={{color: "#418CDD"}}>
+          <div style={{border: "1px solid #418CDD", borderRadius: "50%", width: "2rem", height: "2rem", marginRight: ".75rem"}}><HighlightOutlined />
+          </div>
+          <ListItemText primary={"Source & Code"} />
         </div>
       </Button>
     </>


### PR DESCRIPTION
- [x] Source & Code entrypoint is now distinct from other leftdrawer menu items
- [x] "Open Sandbox" button is now visible in code view

![image](https://user-images.githubusercontent.com/85196294/135693791-fc55ef1d-0fab-48e0-adca-43cd796e2adc.png)
