### PR TITLE
Re-add bottom bar for Code& Source view.

### DIFF
--- a/client/atom/src/components/Home/Home.js
+++ b/client/atom/src/components/Home/Home.js
@@ -162,6 +162,7 @@ export default function Home(props) {
             staticContent={ActiveDemoComponentContent}
             dynamicPadding={drawerOpen && packageName === "vision" ? topAndBottomHeaderPlusDrawerOpen : topAndBottomHeaderSpacing} /> : ''}
         </main>
+        <BottomBar classes={classes} />
       </AppContext.Provider>
     </div>
   )

--- a/client/atom/src/config/Demo/SalesCalendarContent.js
+++ b/client/atom/src/config/Demo/SalesCalendarContent.js
@@ -10,10 +10,6 @@ export const SalesCalendarContent = {
   "description": "Ayeeeeeee",
   "icon": DateRangeOutlinedIcon,
   "component": SalesCalendar,
-  "thumbnail": {
-    id: "5",
-    url: "salesoverview"
-  },
   "lookerContent": [
     {
       "type": "custom vis",

--- a/client/atom/src/config/Demo/SalesOverviewContent.js
+++ b/client/atom/src/config/Demo/SalesOverviewContent.js
@@ -191,6 +191,10 @@ export const SalesOverviewContent = {
   "description": "Overview of all your sales!",
   "icon": VisibilityOutlinedIcon,
   "component": Dashboard,
+  "thumbnail": {
+    id: "5",
+    url: "salesoverview"
+  },
   "lookerContent": [
     {
       "type": "dashboard",

--- a/client/shared/components/Accessories/CodeFlyout.js
+++ b/client/shared/components/Accessories/CodeFlyout.js
@@ -8,7 +8,7 @@ import {API_COLOR, API_BACKGROUND_COLOR, EMBED_COLOR, EMBED_BACKGROUND_COLOR} fr
 
 
 export const CodeFlyout = (props) => {
-  const { codeShow, setCodeShow, setHighlightShow, theme } = useContext(appContextMap[process.env.REACT_APP_PACKAGE_NAME]);
+  const { codeShow, setCodeShow, theme } = useContext(appContextMap[process.env.REACT_APP_PACKAGE_NAME]);
   const { classes, lookerUser, height, staticContent } = props;
   const { codeFlyoutContent } = staticContent || undefined;
   const tabs = [{
@@ -46,7 +46,6 @@ export const CodeFlyout = (props) => {
   function close() {
     setValue(0)
     setCodeShow(false)
-    setHighlightShow(false)
   }
 
   return (

--- a/client/shared/components/LeftDrawer.js
+++ b/client/shared/components/LeftDrawer.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Drawer, IconButton, List, ListItem, ListItemIcon, ListItemText, Button } from '@material-ui/core/';
 import { ChevronLeft, HighlightOutlined } from '@material-ui/icons';
 import {VectorThumbnail} from "./VectorThumbnail"
+import { ApiHighlight } from './Accessories/Highlight';
 const { validIdHelper, appContextMap } = require('../utils/tools');
 
 export const LeftDrawer = ({ DemoComponentsContentArr, classes }) => {
@@ -32,14 +33,6 @@ export const LeftDrawer = ({ DemoComponentsContentArr, classes }) => {
         classes={classes}
         style={{paddingBottom: "2rem"}}
         DemoComponentsContentArr={DemoComponentsContentArr} />
-      <div style={{
-          borderTop: "1px solid #dedede", 
-          height: "2rem",
-          paddingBottom: "1rem",
-          width: "100%"
-          }}>
-          <SourceCode classes={classes}/>
-        </div>
     </Drawer>
   )
 }
@@ -98,6 +91,7 @@ function MenuList({ classes, DemoComponentsContentArr }) {
               return item.thumbnail ?
                 <Link to={to} style={{textDecoration: "none"}}>
                   <div className={classes.menuListItemThumbnailContainer}>
+                  <ApiHighlight classes={classes}>
                     <div className={classes.menuListItemThumbnailHeader}>
                       <ListItemIcon className={classes.menuListItemIcon} >
                         {MatchingIconComponent ? <MatchingIconComponent /> : <></>}
@@ -105,6 +99,7 @@ function MenuList({ classes, DemoComponentsContentArr }) {
                       <ListItemText primary={_.capitalize(item.label)} style={{color: "#418CDD"}}/>
                     </div>
                     {item.thumbnail && <VectorThumbnail classes={classes} {...item.thumbnail}/>}
+                    </ApiHighlight>
                   </div>
                 </Link>
               :(
@@ -132,34 +127,4 @@ function MenuList({ classes, DemoComponentsContentArr }) {
     }
   </List >
   )
-}
-
-
-function SourceCode({classes}) {
-  const { 
-    highlightShow, 
-    setHighlightShow,
-    codeShow, 
-    setCodeShow 
-  } = useContext(appContextMap[process.env.REACT_APP_PACKAGE_NAME])
-
-  function toggle() {
-    const show = !(codeShow || highlightShow);
-    setCodeShow(show);
-    setHighlightShow(show);
-  }
-  return (
-    <>
-      <Button
-        className={`${classes.borderRadius100} ${classes.noBorder} ${classes.menuListItemThumbnailContainer}`}
-        onClick={toggle}
-      >
-        <div className={classes.menuListItemThumbnailHeader} style={{color: "#418CDD"}}>
-          <div style={{border: "1px solid #418CDD", borderRadius: "50%", width: "2rem", height: "2rem", marginRight: ".75rem"}}><HighlightOutlined />
-          </div>
-          <ListItemText primary={"Source & Code"} />
-        </div>
-      </Button>
-    </>
-  );
 }

--- a/client/shared/components/VectorThumbnail.js
+++ b/client/shared/components/VectorThumbnail.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Link } from "react-router-dom";
 import { Grid } from '@material-ui/core';
-import { ApiHighlight } from './Accessories/Highlight';
 import { appContextMap } from '../utils/tools';
 
 export function VectorThumbnail({ classes, id, url }) {
@@ -31,7 +30,6 @@ export function VectorThumbnail({ classes, id, url }) {
   }
 
   return svg ? (
-    <ApiHighlight classes={classes}>
       <div className={classes.vectorThumbnail}>
         <Grid container
           className={`${classes.cursorPointer}`}
@@ -41,6 +39,5 @@ export function VectorThumbnail({ classes, id, url }) {
           </div>
         </Grid >
       </div>
-    </ApiHighlight>
   ) : null;
 }


### PR DESCRIPTION
1. Moved vectorthumbnail from "Sales calendar" to "Sales overview" on left drawer
2. moved ApiHighlight for leftdrawer thumbnails to around the entire item, not just the thumbnail
3. Reinstated bottom bar with separate source+code buttons, removed the "Source & Code" button on bottom left drawer

https://user-images.githubusercontent.com/85196294/138332465-7034579c-a42c-4be5-8c62-b3fffa58a92f.mov
